### PR TITLE
Remove gemspec TODO mentions raising bundler errors

### DIFF
--- a/hipay.gemspec
+++ b/hipay.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = Hipay::VERSION
   spec.authors       = ["itkin"]
   spec.email         = ["nicolas.papon@gmail.com"]
-  spec.summary       = %q{TODO: Hipay TPP client.}
-  spec.description   = %q{TODO: Hipay TPP client.}
+  spec.summary       = %q{Hipay TPP client.}
+  spec.description   = %q{Hipay TPP client.}
   spec.homepage      = ""
   spec.license       = "MIT"
 


### PR DESCRIPTION
Bundler error due to gemspec file :no_good:
The validation error was '"FIXME" or "TODO" is not a description' (Bundler::InvalidOption)